### PR TITLE
Remove unneeded PATH variable

### DIFF
--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -35,8 +35,6 @@
     cmd: microk8s config --use-loopback
   args:
     executable: /bin/bash
-  environment:
-    PATH: '${PATH}:/snap/bin/'
   register: kubectl_config
   changed_when: false
   tags:


### PR DESCRIPTION
This started causing the following error in the latest clean install:
```
TASK [watonomous.microk8s : obtain kubectl config] ********************************************************************************************************************************************************************************************************************************
fatal: [ha-microk8s1]: FAILED! => {"changed": false, "cmd": "microk8s config --use-loopback", "delta": "0:00:00.043354", "end": "2024-08-17 01:31:41.424898", "msg": "non-zero return code", "rc": 127, "start": "2024-08-17 01:31:41.381544", "stderr": "/usr/bin/env: ‘bash’: No such file or directory", "stderr_lines": ["/usr/bin/env: ‘bash’: No such file or directory"], "stdout": "", "stdout_lines": []}
ok: [wato2-microk8s1]
ok: [tr-microk8s1]
ok: [derek2-microk8s1]
```